### PR TITLE
Change requires_python to >=3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from setuptools import setup
-from sys import version_info
 
 
 setup(
@@ -10,7 +9,7 @@ setup(
     long_description='overly is for testing your http client, from the balan to the bananas.',
     license='MIT',
     version='0.1.8',
-    python_requires=">=3.7",
+    python_requires=">=3.6",
     author='Mark Jameson - aka theelous3',
     url='https://github.com/theelous3/overly',
     packages=['overly'],


### PR DESCRIPTION
I see no reason why Python3.6 can't be supported from a short
examination of the project.

I identified commit f180ba4e21bf03f723bba147c2b26a6ea921d5c3 as the one
that introduced the 3.7 version requirement, removing the previous 3.6
requirement but without introducing any 3.7 specific features.

Python3.6 support matters to me because It's the latest version I can use without having to mess with `pyenv` and the cost that comes along with it.

Let me know if this isn't applicable :)